### PR TITLE
Adding serialization behind a feature flag, Make listen_and_simulate not depend on example listen.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,11 +19,11 @@ jobs:
           dependencies: sudo apt install libxtst-dev
         - os: macos-latest
           # TODO: We can't test this on github, we can't set accessibility yet.
-          test: cargo test --verbose -- --skip test_listen_and_simulate
+          test: cargo test --verbose --all-features -- --skip test_listen_and_simulate
         - os: ubuntu-latest
-          test: cargo test --verbose
+          test: cargo test --verbose --all-features
         - os: windows-latest
-          test: cargo test --verbose
+          test: cargo test --verbose --all-features
 
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ xproto = "1.1"
 winapi = { version = "0.3", features = ["winuser", "errhandlingapi", "processthreadsapi"] }
 
 [dev-dependencies]
-tokio = {version = "0.2", features=["process", "rt-core", "io-util", "macros"]}
+tokio = {version = "0.2", features=["process", "rt-core", "io-util", "macros", "time"]}
 lazy_static = "1.4.0"
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ keywords = ["input", "mouse", "testing", "keyboard", "automation"]
 categories = ["development-tools::testing", "api-bindings", "hardware-support"]
 license = "MIT"
 
+[dependencies]
+serde = {version = "1.0", features = ["derive"], optional=true}
+
+[features]
+serialize = ["serde"]
+
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.20"
 core-graphics = {version = "0.19.0", features = ["highsierra"]}
@@ -31,3 +37,9 @@ winapi = { version = "0.3", features = ["winuser", "errhandlingapi", "processthr
 [dev-dependencies]
 tokio = {version = "0.2", features=["process", "rt-core", "io-util", "macros"]}
 lazy_static = "1.4.0"
+serde_json = "1.0"
+
+
+[[example]]
+name = "serialize"
+required-features = ["serialize"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ fn main() {
 }
 ```
 
+Serialization
+
+Serialization and deserialization is optional behind the feature "serialize".
+
 ### Event struct
 
 In order to detect what a user types, we need to plug to the OS level management

--- a/examples/listen.rs
+++ b/examples/listen.rs
@@ -10,7 +10,7 @@ fn main() {
 fn callback(event: Event) {
     println!("My callback {:?}", event);
     match event.name {
-        Some(string) => println!("User wrote {:?}", string),
+        Some(_) => (), // println!("User wrote {:?}", string),
         None => (),
     }
 }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -15,4 +15,5 @@ fn main() {
 
     println!("Serialized event {:?}", serialized);
     println!("Deserialized event {:?}", deserialized);
+    assert_eq!(event, deserialized);
 }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -1,0 +1,18 @@
+use rdev::{Event, EventType, Key};
+use serde_json;
+use std::time::SystemTime;
+
+fn main() {
+    let event = Event {
+        event_type: EventType::KeyPress(Key::KeyS),
+        time: SystemTime::now(),
+        name: Some(String::from("S")),
+    };
+
+    let serialized = serde_json::to_string(&event).unwrap();
+
+    let deserialized: Event = serde_json::from_str(&serialized).unwrap();
+
+    println!("Serialized event {:?}", serialized);
+    println!("Deserialized event {:?}", deserialized);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,9 @@
 //! assert!(w > 0);
 //! assert!(h > 0);
 //! ```
+//! Serialization
+//!
+//! Serialization and deserialization is optional behind the feature "serialize".
 mod rdev;
 pub use crate::rdev::{Button, Callback, Event, EventType, Key, ListenError, SimulateError};
 

--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -34,7 +34,7 @@ pub struct SimulateError;
 /// a different value too.
 /// Careful, on Windows KpReturn does not exist, it' s strictly equivalent to Return, also Keypad keys
 /// get modified if NumLock is Off and ARE pagedown and so on.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum Key {
     /// Alt key on Linux and Windows (option key on macOS)
@@ -149,7 +149,7 @@ pub enum Key {
 }
 
 /// Standard mouse buttons
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum Button {
     Left,
@@ -160,7 +160,7 @@ pub enum Button {
 
 /// In order to manage different OS, the current EventType choices is a mix&match
 /// to account for all possible events.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum EventType {
     /// The keys correspond to a standard qwerty layout, they don't correspond
@@ -190,7 +190,7 @@ pub enum EventType {
 /// on the OS layout and keyboard state machinery.
 /// Caveat: Dead keys don't function on Linux(X11) yet. You will receive None for
 /// a dead key, and the raw letter instead of accentuated letter instead.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Event {
     pub time: SystemTime,

--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -35,6 +35,7 @@ pub struct SimulateError;
 /// Careful, on Windows KpReturn does not exist, it' s strictly equivalent to Return, also Keypad keys
 /// get modified if NumLock is Off and ARE pagedown and so on.
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum Key {
     /// Alt key on Linux and Windows (option key on macOS)
     Alt,
@@ -149,6 +150,7 @@ pub enum Key {
 
 /// Standard mouse buttons
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum Button {
     Left,
     Right,
@@ -159,6 +161,7 @@ pub enum Button {
 /// In order to manage different OS, the current EventType choices is a mix&match
 /// to account for all possible events.
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum EventType {
     /// The keys correspond to a standard qwerty layout, they don't correspond
     /// To the actual letter a user would use, that requires some layout logic to be added.
@@ -188,6 +191,7 @@ pub enum EventType {
 /// Caveat: Dead keys don't function on Linux(X11) yet. You will receive None for
 /// a dead key, and the raw letter instead of accentuated letter instead.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Event {
     pub time: SystemTime,
     pub name: Option<String>,

--- a/tests/listen_and_simulate.rs
+++ b/tests/listen_and_simulate.rs
@@ -1,62 +1,61 @@
 extern crate rdev;
 extern crate tokio;
 use rdev::{simulate, EventType, Key};
-
-use std::process::Stdio;
-use std::thread;
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
-use tokio::time::timeout;
+use lazy_static::lazy_static;
+use rdev::{listen, Event};
+use std::thread;
+use std::sync::Mutex;
+use std::sync::mpsc::{channel, Receiver, Sender};
+
+lazy_static! {
+    static ref EVENT_CHANNEL: (Mutex<Sender<Event>>, Mutex<Receiver<Event>>) = {
+        let (send, recv) = channel();
+        (Mutex::new(send), Mutex::new(recv))
+    };
+}
+
+fn send_event(event: Event) {
+    EVENT_CHANNEL
+        .0
+        .lock()
+        .expect("Failed to unlock Mutex")
+        .send(event)
+        .expect("Receiving end of EVENT_CHANNEL was closed");
+}
 
 #[tokio::test]
 async fn test_listen_and_simulate() {
-    let mut cmd = Command::new("cargo");
-    cmd.arg("run").arg("--example").arg("listen");
-    cmd.kill_on_drop(true);
-
-    // Specify that we want the command's standard output piped back to us.
-    // By default, standard input/output/error will be inherited from the
-    // current process (for example, this means that standard input will
-    // come from the keyboard and standard output/error will go directly to
-    // the terminal if this process is invoked from the command line).
-    cmd.stdout(Stdio::piped());
-
-    let mut child = cmd.spawn().expect("failed to spawn command");
-
-    let stdout = child
-        .stdout
-        .take()
-        .expect("child did not have a handle to stdout");
-
-    let mut reader = BufReader::new(stdout).lines();
-
-    // Ensure the child process is spawned in the runtime so it can
-    // make progress on its own while we await for any output.
-    tokio::spawn(async {
-        let status = child.await.expect("child process encountered an error");
-
-        println!("child status was: {}", status);
+    // spawn new thread because listen blocks
+    let _listener = thread::spawn(move || {
+        listen(send_event).expect("Could not listen");
     });
+
+    let recv = EVENT_CHANNEL.1.lock().expect("Failed to unlock Mutex");
 
     // Wait for listen to start
     thread::sleep(Duration::from_secs(1));
 
+
     let event_type = EventType::KeyPress(Key::KeyS);
+    let event_type2 = EventType::KeyRelease(Key::KeyS);
     let result = simulate(&event_type);
     assert!(result.is_ok());
-    let result = simulate(&EventType::KeyRelease(Key::KeyS));
+    let result = simulate(&event_type2);
     assert!(result.is_ok());
-
-    let string = format!("{:?}", event_type);
-    let fut = timeout(Duration::from_secs(1), reader.next_line());
-    match fut.await{
-        Ok(Ok(Some(line))) => {
-            println!("Received line {:?}", line);
-            assert!(line.contains(&string));
-        },
-        Ok(Ok(None)) => {assert!(false, "Empty stdout");}
-        Ok(Err(_)) => {assert!(false, "Error reading stdout");}
-        Err(_) => {assert!(false, "Timeout expired !");}
+    let timeout =  Duration::from_secs(1);
+    match recv.recv_timeout(timeout){
+        Ok(event1) => {
+            assert_eq!(event1.event_type, event_type);
+        }
+        Err(err) => assert!(false, format!("Timeout error : {:?}", err))
     }
+    match recv.recv_timeout(timeout){
+        Ok(event2) => {
+            assert_eq!(event2.event_type, event_type2);
+        }
+        Err(err) => assert!(false, format!("Timeout error : {:?}", err))
+    }
+
+
 }


### PR DESCRIPTION
Fixes #24