### PR TITLE
Bumping version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdev"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Nicolas Patry <patry.nicolas@protonmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Version mostly fixed too many clients error on Linux (x11)

- Added a channel example to use listen within a thread.
- Fixed all clippy warnings.