### PR TITLE
feat: added hash and eq traits to key

### DIFF
--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -97,7 +97,7 @@ impl std::error::Error for SimulateError {}
 /// a different value too.
 /// Careful, on Windows KpReturn does not exist, it' s strictly equivalent to Return, also Keypad keys
 /// get modified if NumLock is Off and ARE pagedown and so on.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Key {
     /// Alt key on Linux and Windows (option key on macOS)


### PR DESCRIPTION
It seems that there is no reason why the Key should not have `Eq` and `Hash` traits implemented on it. This is particularly helpful if you're working with this crate and want to ensure that the keys match a specified key. I had such a use case and tried this out deriving these and it seems to work perfectly.