### PR TITLE
fix: panic when using CJK input methods in macOS

### DIFF
--- a/src/macos/keyboard.rs
+++ b/src/macos/keyboard.rs
@@ -95,7 +95,7 @@ impl Keyboard {
         let mut layout = TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData);
 
         if layout.is_null() {
-            // TISGetInputSourceProperty returns NULL when using CJK input methods, 
+            // TISGetInputSourceProperty returns NULL when using CJK input methods,
             // using TISCopyCurrentKeyboardLayoutInputSource to fix it.
             keyboard = TISCopyCurrentKeyboardLayoutInputSource();
             layout = TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData);
@@ -103,7 +103,6 @@ impl Keyboard {
                 return None;
             }
         }
-        
         let layout_ptr = CFDataGetBytePtr(layout);
 
         let mut buff = [0_u16; BUF_LEN];

--- a/src/macos/keyboard.rs
+++ b/src/macos/keyboard.rs
@@ -35,6 +35,7 @@ const BUF_LEN: usize = 4;
 #[link(name = "Cocoa", kind = "framework")]
 #[link(name = "Carbon", kind = "framework")]
 extern "C" {
+    fn TISCopyCurrentKeyboardLayoutInputSource() -> TISInputSourceRef;
     fn TISCopyCurrentKeyboardInputSource() -> TISInputSourceRef;
     fn TISGetInputSourceProperty(source: TISInputSourceRef, property: *mut c_void) -> CFDataRef;
     fn UCKeyTranslate(
@@ -90,8 +91,19 @@ impl Keyboard {
         code: u32,
         modifier_state: ModifierState,
     ) -> Option<String> {
-        let keyboard = TISCopyCurrentKeyboardInputSource();
-        let layout = TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData);
+        let mut keyboard = TISCopyCurrentKeyboardInputSource();
+        let mut layout = TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData);
+
+        if layout.is_null() {
+            // TISGetInputSourceProperty returns NULL when using CJK input methods, 
+            // using TISCopyCurrentKeyboardLayoutInputSource to fix it.
+            keyboard = TISCopyCurrentKeyboardLayoutInputSource();
+            layout = TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData);
+            if layout.is_null() {
+                return None;
+            }
+        }
+        
         let layout_ptr = CFDataGetBytePtr(layout);
 
         let mut buff = [0_u16; BUF_LEN];


### PR DESCRIPTION
Related issue and comment: https://github.com/Narsil/rdev/issues/86#issuecomment-1312354356

When I am using a Chinese/Japanese input methods, `TISCopyCurrentKeyboardInputSource` would return NULL, leading to a segment fault in `CFDataGetBytePtr(layout)` because layout is NULL.

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/53432474/208033249-ef263245-c556-4ed3-a165-e7fc1626b698.png">

So I handled this case by using `TISCopyCurrentKeyboardLayoutInputSource`, inspired by a similar case in VSCode.
related issue: https://github.com/microsoft/vscode/issues/23833#issuecomment-291366154
and code: https://github.com/microsoft/node-native-keymap/blob/089d802efd387df4dce1f0e31898c66e28b3f67f/src/keyboard_mac.mm#L87

<img width="1110" alt="image" src="https://user-images.githubusercontent.com/53432474/208033319-2646f299-731e-4247-8913-72f490645a17.png">

My environment: 
MacOS 12.5 (Apple Silicon)
Rust 1.62.1