### PR TITLE
remove winapi as dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,13 @@ epoll = {version = "4.1.0", optional=true}
 inotify = {version = "0.8.2", default-features=false, optional=true}
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["winuser", "errhandlingapi", "processthreadsapi"] }
+windows-sys = { version = "0.45.0", features = [
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_TextServices"
+] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/windows/display.rs
+++ b/src/windows/display.rs
@@ -1,6 +1,6 @@
 use crate::rdev::DisplayError;
 use std::convert::TryInto;
-use winapi::um::winuser::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
+use windows_sys::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
 
 pub fn display_size() -> Result<(u64, u64), DisplayError> {
     let w = unsafe {

--- a/src/windows/keycodes.rs
+++ b/src/windows/keycodes.rs
@@ -1,6 +1,6 @@
 use crate::rdev::Key;
+use crate::windows::WORD;
 use std::convert::TryInto;
-use winapi::shared::minwindef::WORD;
 
 macro_rules! decl_keycodes {
     ($($key:ident, $code:literal),*) => {

--- a/src/windows/listen.rs
+++ b/src/windows/listen.rs
@@ -3,8 +3,8 @@ use crate::windows::common::{convert, set_key_hook, set_mouse_hook, HookError, H
 use std::os::raw::c_int;
 use std::ptr::null_mut;
 use std::time::SystemTime;
-use winapi::shared::minwindef::{LPARAM, LRESULT, WPARAM};
-use winapi::um::winuser::{CallNextHookEx, GetMessageA, HC_ACTION};
+use windows_sys::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
+use windows_sys::Win32::UI::WindowsAndMessaging::{CallNextHookEx, GetMessageA, HC_ACTION};
 
 static mut GLOBAL_CALLBACK: Option<Box<dyn FnMut(Event)>> = None;
 
@@ -18,7 +18,7 @@ impl From<HookError> for ListenError {
 }
 
 unsafe extern "system" fn raw_callback(code: c_int, param: WPARAM, lpdata: LPARAM) -> LRESULT {
-    if code == HC_ACTION {
+    if code == HC_ACTION as i32 {
         let opt = convert(param, lpdata);
         if let Some(event_type) = opt {
             let name = match &event_type {
@@ -50,7 +50,7 @@ where
         set_key_hook(raw_callback)?;
         set_mouse_hook(raw_callback)?;
 
-        GetMessageA(null_mut(), null_mut(), 0, 0);
+        GetMessageA(null_mut(), 0, 0, 0);
     }
     Ok(())
 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,5 +1,3 @@
-extern crate winapi;
-
 mod common;
 mod display;
 #[cfg(feature = "unstable_grab")]
@@ -15,3 +13,8 @@ pub use crate::windows::grab::grab;
 pub use crate::windows::keyboard::Keyboard;
 pub use crate::windows::listen::listen;
 pub use crate::windows::simulate::simulate;
+
+// types not defined by windows-sys
+pub type DWORD = u32;
+pub type WORD = u16;
+pub type LONG = i32;


### PR DESCRIPTION
The changes include, Migrating from `winapi` to `windows-sys`: `winapi` is no longer maintained in favor of [`windows-rs`](https://github.com/microsoft/windows-rs) which is provided by Microsoft itself. It should provide more robustness against future windows upgrade and better compile and runtime guarantees.

This is the continuation of #97 

- You were right about `cargo` profile changes, they are overwritten by end binary
- I have removed any clippy changes, they should have been a separate pull
- I had no idea about global `.gitignore`, so that's a pretty good thing to learn
- I have put the types in `mod.rs` as public
- I did not undertsand your comment about removing the global `HOOK`, aren't we modifying it at `set_key_hook` & `set_mouse_hook`