### PR TITLE
Add Control Right to Mac keycodes

### DIFF
--- a/src/macos/keycodes.rs
+++ b/src/macos/keycodes.rs
@@ -8,8 +8,8 @@ const ALT: CGKeyCode = 58;
 const ALT_GR: CGKeyCode = 61;
 const BACKSPACE: CGKeyCode = 51;
 const CAPS_LOCK: CGKeyCode = 57;
-/// Control Right does not exist on Mac
 const CONTROL_LEFT: CGKeyCode = 59;
+const CONTROL_RIGHT: CGKeyCode = 62;
 const DOWN_ARROW: CGKeyCode = 125;
 const ESCAPE: CGKeyCode = 53;
 const F1: CGKeyCode = 122;
@@ -90,6 +90,7 @@ pub fn code_from_key(key: Key) -> Option<CGKeyCode> {
         Key::Backspace => Some(BACKSPACE),
         Key::CapsLock => Some(CAPS_LOCK),
         Key::ControlLeft => Some(CONTROL_LEFT),
+        Key::ControlRight => Some(CONTROL_RIGHT),
         Key::DownArrow => Some(DOWN_ARROW),
         Key::Escape => Some(ESCAPE),
         Key::F1 => Some(F1),


### PR DESCRIPTION
According to https://eastmanreference.com/complete-list-of-applescript-key-codes and https://github.com/servo/core-foundation-rs/blob/8c2444066aac42c20443b696270f5b1afff18993/core-graphics/src/event.rs#LL62C45-L62C45 the Control Right key actually does exist, although many keyboards don't have it. I was experiencing a crash in kanata (a Rust keyboard mapper a la kmonad) related to this, so it would be nice to have it fixed :)