### PR TITLE
Xlib horizontal wheel

### DIFF
--- a/src/linux/common.rs
+++ b/src/linux/common.rs
@@ -23,8 +23,6 @@ pub fn convert_event(code: c_uchar, type_: c_int, x: f64, y: f64) -> Option<Even
             let key = key_from_code(code.into());
             Some(EventType::KeyRelease(key))
         }
-        // Xlib does not implement wheel events left and right afaik.
-        // But MacOS does, so we need to acknowledge the larger event space.
         xlib::ButtonPress => match code {
             1 => Some(EventType::ButtonPress(Button::Left)),
             2 => Some(EventType::ButtonPress(Button::Middle)),
@@ -36,6 +34,14 @@ pub fn convert_event(code: c_uchar, type_: c_int, x: f64, y: f64) -> Option<Even
             5 => Some(EventType::Wheel {
                 delta_y: -1,
                 delta_x: 0,
+            }),
+            6 => Some(EventType::Wheel {
+                delta_y: 0,
+                delta_x: -1,
+            }),
+            7 => Some(EventType::Wheel {
+                delta_y: 0,
+                delta_x: 1,
             }),
             code => Some(EventType::ButtonPress(Button::Unknown(code))),
         },

--- a/src/linux/simulate.rs
+++ b/src/linux/simulate.rs
@@ -52,10 +52,22 @@ unsafe fn send_native(event_type: &EventType, display: *mut xlib::Display) -> Op
             xtest::XTestFakeMotionEvent(display, 0, x, y, 0)
             //     xlib::XWarpPointer(display, 0, root, 0, 0, 0, 0, *x as i32, *y as i32);
         }
-        EventType::Wheel { delta_y, .. } => {
-            let code = if *delta_y > 0 { 4 } else { 5 };
-            xtest::XTestFakeButtonEvent(display, code, TRUE, 0)
-                & xtest::XTestFakeButtonEvent(display, code, FALSE, 0)
+        EventType::Wheel { delta_x, delta_y } => {
+            let code_x = if *delta_x > 0 { 7 } else { 6 };
+            let code_y = if *delta_y > 0 { 4 } else { 5 };
+
+            let mut result: c_int = 1;
+            for _ in 0..delta_x.abs() {
+                result = result
+                    & xtest::XTestFakeButtonEvent(display, code_x, TRUE, 0)
+                    & xtest::XTestFakeButtonEvent(display, code_x, FALSE, 0)
+            }
+            for _ in 0..delta_y.abs() {
+                result = result
+                    & xtest::XTestFakeButtonEvent(display, code_y, TRUE, 0)
+                    & xtest::XTestFakeButtonEvent(display, code_y, FALSE, 0)
+            }
+            result
         }
     };
     if res == 0 {

--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -244,8 +244,6 @@ pub enum EventType {
     /// `delta_y` represents vertical scroll and `delta_x` represents horizontal scroll.
     /// Positive values correspond to scrolling up or right and negative values
     /// correspond to scrolling down or left
-    /// Note: Linux does not support horizontal scroll. When simulating scroll on Linux,
-    /// only the sign of delta_y is considered, and not the magnitude to determine wheelup or wheeldown.
     Wheel {
         delta_x: i64,
         delta_y: i64,


### PR DESCRIPTION
Adds support for horizontal scrolling for Linux, tested on Pop!_OS 22.04.

Note that in `send_native`, y-direction must be done first, or only one direction will trigger.

I hope this helps!