### PR TITLE
Update Key enum with implementations of PartialOrd and Ord traits.

### DIFF
--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -97,7 +97,7 @@ impl std::error::Error for SimulateError {}
 /// a different value too.
 /// Careful, on Windows KpReturn does not exist, it' s strictly equivalent to Return, also Keypad keys
 /// get modified if NumLock is Off and ARE pagedown and so on.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Key {
     /// Alt key on Linux and Windows (option key on macOS)


### PR DESCRIPTION
I need to use `std::collections::BTreeSet` to store `rdev::Key`, but `rdev::Key` does not implement `PartialOrd, Ord` trait, I want to add these two traits
