### PR TITLE
Fix CapsLock handling of `Keyboard` for Windows.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,6 +398,22 @@ mod tests {
         assert_eq!(n, None);
         keyboard.add(&EventType::KeyRelease(Key::ShiftLeft));
 
+        // CapsLock
+        let char_c = keyboard.add(&EventType::KeyPress(Key::KeyC)).unwrap();
+        assert_eq!(char_c, "c".to_string());
+        keyboard.add(&EventType::KeyPress(Key::CapsLock));
+        keyboard.add(&EventType::KeyRelease(Key::CapsLock));
+        let char_c = keyboard.add(&EventType::KeyPress(Key::KeyC)).unwrap();
+        assert_eq!(char_c, "C".to_string());
+        let n = keyboard.add(&EventType::KeyRelease(Key::KeyS));
+        assert_eq!(n, None);
+        keyboard.add(&EventType::KeyPress(Key::CapsLock));
+        keyboard.add(&EventType::KeyRelease(Key::CapsLock));
+        let char_c = keyboard.add(&EventType::KeyPress(Key::KeyC)).unwrap();
+        assert_eq!(char_c, "c".to_string());
+        let n = keyboard.add(&EventType::KeyRelease(Key::KeyS));
+        assert_eq!(n, None);
+
         // UsIntl layout required
         // let n = keyboard.add(&EventType::KeyPress(Key::Quote));
         // assert_eq!(n, Some("".to_string()));

--- a/src/windows/keyboard.rs
+++ b/src/windows/keyboard.rs
@@ -142,7 +142,7 @@ impl KeyboardState for Keyboard {
                     None
                 }
                 Key::CapsLock => {
-                    self.last_state[VK_CAPITAL_] ^= HIGHBIT;
+                    self.last_state[VK_CAPITAL_] ^= 1;
                     None
                 }
                 key => {


### PR DESCRIPTION
This should fix #110 

The root cause of the bug is a misunderstanding of the `lpKeyState` argument of `ToUnicodeEx`. The [MSDN](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-tounicodeex) says:

> If the high-order bit of a byte is set, the key is down. **The low bit, if set, indicates that the key is toggled on. In this function, only the toggle bit of the CAPS LOCK key is relevant.**

Thus we should toggle the CapsLock state using the low bit.