### PR TITLE
Include scan code when simulating keyboard events on Windows

### DIFF
--- a/src/windows/keycodes.rs
+++ b/src/windows/keycodes.rs
@@ -1,6 +1,18 @@
 use crate::rdev::Key;
 use std::convert::TryInto;
 use winapi::shared::minwindef::WORD;
+use winapi::um::winuser::{MapVirtualKeyA, MAPVK_VK_TO_VSC};
+
+pub fn scan_from_code(code: WORD) -> Option<WORD> {
+    let scan = unsafe { MapVirtualKeyA(code as u32, MAPVK_VK_TO_VSC) } as WORD;
+
+    if scan != 0 {
+        Some(scan)
+    }
+    else {
+        None
+    }
+}
 
 macro_rules! decl_keycodes {
     ($($key:ident, $code:literal),*) => {

--- a/src/windows/simulate.rs
+++ b/src/windows/simulate.rs
@@ -1,5 +1,5 @@
 use crate::rdev::{Button, EventType, SimulateError};
-use crate::windows::keycodes::code_from_key;
+use crate::windows::keycodes::{code_from_key, scan_from_code};
 use std::convert::TryFrom;
 use std::mem::size_of;
 use winapi::ctypes::{c_int, c_short};
@@ -77,11 +77,13 @@ pub fn simulate(event_type: &EventType) -> Result<(), SimulateError> {
     match event_type {
         EventType::KeyPress(key) => {
             let code = code_from_key(*key).ok_or(SimulateError)?;
-            sim_keyboard_event(KEYEVENTF_KEYDOWN, code, 0)
+            let scan = scan_from_code(code).ok_or(SimulateError)?;
+            sim_keyboard_event(KEYEVENTF_KEYDOWN, code, scan)
         }
         EventType::KeyRelease(key) => {
             let code = code_from_key(*key).ok_or(SimulateError)?;
-            sim_keyboard_event(KEYEVENTF_KEYUP, code, 0)
+            let scan = scan_from_code(code).ok_or(SimulateError)?;
+            sim_keyboard_event(KEYEVENTF_KEYUP, code, scan)
         }
         EventType::ButtonPress(button) => match button {
             Button::Left => sim_mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0),


### PR DESCRIPTION
While trying to get keypresses detected by Factorio I noticed it would only work when the proper scan codes are included in the call to `SendInput`.

This should also fix https://github.com/Narsil/rdev/issues/73 according to https://github.com/rustdesk/rustdesk/issues/366#issuecomment-1019758259.

I'm not super familiar with the Windows API and came across a more complete-looking implementation at https://github.com/fufesou/rdev/blob/560eb62adfaa1e53b77d80800904b3241812e284/src/windows/simulate.rs#L116-L134, but maybe this PR is a good starting point?