### PR TITLE
make grab FnMut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,7 +359,7 @@ pub use crate::windows::grab as _grab;
 #[cfg(feature = "unstable_grab")]
 pub fn grab<T>(callback: T) -> Result<(), GrabError>
 where
-    T: Fn(Event) -> Option<Event> + 'static,
+    T: FnMut(Event) -> Option<Event> + 'static,
 {
     _grab(callback)
 }


### PR DESCRIPTION
I want to use a mutable object in callback.

I want to write a code like this:

```rust
    let mut handler = Handler::new(6);
    if let Err(error) = grab(move |event| {
        handler.callback(event)
    }) {
        println!("Error: {:?}", error)
    }

struct Handler {
    buffer: VecDeque<Key>,
    capacity: usize,
    modifiers: HashSet<Modifier>,
}

impl Handler {
    fn new(capacity: usize) -> Handler {
        Handler {
            buffer: VecDeque::with_capacity(capacity),
            capacity,
            modifiers: HashSet::new(),
        }
    }

    fn callback(&mut self, event: Event) -> Option<Event> {
        // implement here.
    }
}

```
