### PR TITLE
provide stop_listen function for user to stop listen in another thread

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,10 @@ mod macos;
 #[cfg(target_os = "macos")]
 pub use crate::macos::Keyboard;
 #[cfg(target_os = "macos")]
-use crate::macos::{display_size as _display_size, listen as _listen, simulate as _simulate};
+use crate::macos::{
+    display_size as _display_size, listen as _listen, simulate as _simulate,
+    stop_listen as _stop_listen,
+};
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -270,6 +273,10 @@ where
     T: FnMut(Event) + 'static,
 {
     _listen(callback)
+}
+
+pub fn stop_listen() {
+    _stop_listen()
 }
 
 /// Sending some events

--- a/src/macos/common.rs
+++ b/src/macos/common.rs
@@ -75,9 +75,8 @@ extern "C" {
     pub fn CFRunLoopGetCurrent() -> CFRunLoopRef;
     pub fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
     pub fn CFRunLoopRun();
-
+    pub fn CFRunLoopStop(rl: CFRunLoopRef);
     pub static kCFRunLoopCommonModes: CFRunLoopMode;
-
 }
 
 // TODO Remove this, this was added as the coded

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -12,4 +12,5 @@ pub use crate::macos::display::display_size;
 pub use crate::macos::grab::grab;
 pub use crate::macos::keyboard::Keyboard;
 pub use crate::macos::listen::listen;
+pub use crate::macos::listen::stop_listen;
 pub use crate::macos::simulate::simulate;


### PR DESCRIPTION
I'm not sure if it is correct of stopping listen on macos, this is my first time to contribute code, so please check them carefully.
really hope to help users. :)
```rust
//stop listen example
use std::{
    thread::{self, spawn},
    time::Duration,
};

use rdev::{listen, stop_listen, Event};

fn main() {
    spawn(|| {
        if let Err(error) = listen(callback) {
            println!("Error: {:?}", error)
        }
    });
    thread::sleep(Duration::from_secs(5));
    spawn(|| stop_listen());
    println!("listen loop is stopped");
    thread::sleep(Duration::from_secs(3600));
}

fn callback(event: Event) {
    println!("My callback {:?}", event);
}


```