### PR TITLE
Stop listen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,10 @@ mod macos;
 #[cfg(target_os = "macos")]
 pub use crate::macos::Keyboard;
 #[cfg(target_os = "macos")]
-use crate::macos::{display_size as _display_size, listen as _listen, simulate as _simulate};
+use crate::macos::{
+    display_size as _display_size, listen as _listen, simulate as _simulate,
+    stop_listen as _stop_listen,
+};
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -242,7 +245,10 @@ mod windows;
 #[cfg(target_os = "windows")]
 pub use crate::windows::Keyboard;
 #[cfg(target_os = "windows")]
-use crate::windows::{display_size as _display_size, listen as _listen, simulate as _simulate};
+use crate::windows::{
+    display_size as _display_size, listen as _listen, simulate as _simulate,
+    stop_listen as _stop_listen,
+};
 
 /// Listening to global events. Caveat: On MacOS, you require the listen
 /// loop needs to be the primary app (no fork before) and need to have accessibility
@@ -270,6 +276,10 @@ where
     T: FnMut(Event) + 'static,
 {
     _listen(callback)
+}
+
+pub fn stop_listen() {
+    _stop_listen();
 }
 
 /// Sending some events

--- a/src/macos/common.rs
+++ b/src/macos/common.rs
@@ -75,7 +75,7 @@ extern "C" {
     pub fn CFRunLoopGetCurrent() -> CFRunLoopRef;
     pub fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
     pub fn CFRunLoopRun();
-
+    pub fn CFRunLoopStop(rl: CFRunLoopRef);
     pub static kCFRunLoopCommonModes: CFRunLoopMode;
 
 }

--- a/src/macos/listen.rs
+++ b/src/macos/listen.rs
@@ -70,8 +70,8 @@ where
 pub fn stop_listen() {
     unsafe {
         if let Some(stop_loop) = STOP_LOOP.as_ref() {
-            STOP_LOOP = None;
             stop_loop();
+            STOP_LOOP = None;
         }
     }
 }

--- a/src/macos/listen.rs
+++ b/src/macos/listen.rs
@@ -70,6 +70,7 @@ where
 pub fn stop_listen() {
     unsafe {
         if let Some(stop_loop) = STOP_LOOP.as_ref() {
+            STOP_LOOP = None;
             stop_loop();
         }
     }

--- a/src/macos/listen.rs
+++ b/src/macos/listen.rs
@@ -22,7 +22,7 @@ unsafe extern "C" fn raw_callback(
     let opt = KEYBOARD_STATE.lock();
     if let Ok(mut keyboard) = opt {
         if let Some(event) = convert(_type, &cg_event, &mut keyboard) {
-            if let Some(callback) = &mut GLOBAL_CALLBACK {
+            if let Some(ref mut callback) = GLOBAL_CALLBACK {
                 callback(event);
             }
         }

--- a/src/macos/listen.rs
+++ b/src/macos/listen.rs
@@ -59,7 +59,21 @@ where
         CFRunLoopAddSource(current_loop, _loop, kCFRunLoopCommonModes);
 
         CGEventTapEnable(tap, true);
+        STOP_LOOP = Some(Box::new(move || {
+            CFRunLoopStop(current_loop);
+        }));
         CFRunLoopRun();
     }
     Ok(())
 }
+
+pub fn stop_listen() {
+    unsafe {
+        if let Some(stop_loop) = STOP_LOOP.as_ref() {
+            stop_loop();
+        }
+    }
+}
+
+type DynFn = dyn Fn() + 'static;
+pub static mut STOP_LOOP: Option<Box<DynFn>> = None;

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -12,4 +12,5 @@ pub use crate::macos::display::display_size;
 pub use crate::macos::grab::grab;
 pub use crate::macos::keyboard::Keyboard;
 pub use crate::macos::listen::listen;
+pub use crate::macos::listen::stop_listen;
 pub use crate::macos::simulate::simulate;

--- a/src/windows/listen.rs
+++ b/src/windows/listen.rs
@@ -71,6 +71,7 @@ pub fn stop_listen() {
     unsafe {
         if let Some(stop_loop) = STOP_LOOP.as_ref() {
             stop_loop();
+            STOP_LOOP = None;
         }
     }
 }

--- a/src/windows/listen.rs
+++ b/src/windows/listen.rs
@@ -34,7 +34,7 @@ unsafe extern "system" fn raw_callback(code: c_int, param: WPARAM, lpdata: LPARA
                 time: SystemTime::now(),
                 name,
             };
-            if let Some(callback) = &mut GLOBAL_CALLBACK {
+            if let Some(ref mut callback) = GLOBAL_CALLBACK {
                 callback(event);
             }
         }
@@ -58,7 +58,6 @@ where
         loop {
             if let Ok(stop_listen) = receiver.try_recv() {
                 if stop_listen {
-                    println!("stop loop successed");
                     break;
                 }
             }

--- a/src/windows/listen.rs
+++ b/src/windows/listen.rs
@@ -2,6 +2,7 @@ use crate::rdev::{Event, EventType, ListenError};
 use crate::windows::common::{convert, set_key_hook, set_mouse_hook, HookError, HOOK, KEYBOARD};
 use std::os::raw::c_int;
 use std::ptr::null_mut;
+use std::sync::mpsc;
 use std::time::SystemTime;
 use winapi::shared::minwindef::{LPARAM, LRESULT, WPARAM};
 use winapi::um::winuser::{CallNextHookEx, PeekMessageA, HC_ACTION};

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -14,4 +14,5 @@ pub use crate::windows::display::display_size;
 pub use crate::windows::grab::grab;
 pub use crate::windows::keyboard::Keyboard;
 pub use crate::windows::listen::listen;
+pub use crate::windows::listen::stop_listen;
 pub use crate::windows::simulate::simulate;

--- a/tests/stop_listen.rs
+++ b/tests/stop_listen.rs
@@ -1,0 +1,23 @@
+use rdev::{listen, stop_listen};
+use serial_test::serial;
+use std::{
+    thread::{self, spawn},
+    time::Duration,
+};
+#[test]
+#[serial]
+fn test_stop() {
+    eprintln!("hello");
+    spawn(|| {
+        if let Err(error) = listen(|event| {
+            println!("My callback {:?}", event);
+        }) {
+            println!("Error: {:?}", error)
+        }
+    });
+    thread::sleep(Duration::from_secs(5));
+    spawn(|| {
+        stop_listen();
+    });
+    thread::sleep(Duration::from_secs(5));
+}


### PR DESCRIPTION
Supported on macos and windows, I'm a newbie of Rust, so please check it carefully.

```rust
use std::{
    thread::{self, spawn},
    time::Duration,
};

use rdev::{listen, stop_listen};

fn main() {
    spawn(|| {
        println!("start");
        if let Err(error) = listen(|event| {
            println!("My callback {:?}", event);
        }) {
            println!("Error: {:?}", error)
        }
        println!("end");
    });
    thread::sleep(Duration::from_secs(5));
    spawn(|| {
        stop_listen();
    });
    thread::sleep(Duration::from_secs(3600));
}
```