### PR TITLE
Add drag event on macos

### DIFF
--- a/examples/simulate.rs
+++ b/examples/simulate.rs
@@ -19,8 +19,16 @@ fn main() {
 
     send(&EventType::MouseMove { x: 0.0, y: 0.0 });
     send(&EventType::MouseMove { x: 400.0, y: 400.0 });
-    send(&EventType::ButtonPress(Button::Left));
-    send(&EventType::ButtonRelease(Button::Right));
+    send(&EventType::ButtonPress {
+        button: Button::Left,
+        x: None,
+        y: None,
+    });
+    send(&EventType::ButtonRelease {
+        button: Button::Right,
+        x: None,
+        y: None,
+    });
     send(&EventType::Wheel {
         delta_x: 0,
         delta_y: 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,8 +246,8 @@ mod windows;
 pub use crate::windows::Keyboard;
 #[cfg(target_os = "windows")]
 use crate::windows::{
-    display_size as _display_size, listen as _listen, simulate as _simulate,
-    stop_listen as _stop_listen,
+    display_size as _display_size, get_current_mouse_location as _get_current_mouse_location,
+    listen as _listen, simulate as _simulate, stop_listen as _stop_listen,
 };
 
 /// Listening to global events. Caveat: On MacOS, you require the listen
@@ -280,6 +280,25 @@ where
 
 pub fn stop_listen() {
     _stop_listen();
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+pub fn get_current_mouse_location() -> Option<Point> {
+    unsafe {
+        if let Some(point) = _get_current_mouse_location() {
+            Some(Point {
+                x: point.x as f64,
+                y: point.y as f64,
+            })
+        } else {
+            None
+        }
+    }
 }
 
 /// Sending some events

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,8 +229,8 @@ mod macos;
 pub use crate::macos::Keyboard;
 #[cfg(target_os = "macos")]
 use crate::macos::{
-    display_size as _display_size, listen as _listen, simulate as _simulate,
-    stop_listen as _stop_listen,
+    display_size as _display_size, get_current_mouse_location as _get_current_mouse_location,
+    listen as _listen, simulate as _simulate, stop_listen as _stop_listen,
 };
 
 #[cfg(target_os = "linux")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,10 @@ mod macos;
 #[cfg(target_os = "macos")]
 pub use crate::macos::Keyboard;
 #[cfg(target_os = "macos")]
-use crate::macos::{display_size as _display_size, listen as _listen, simulate as _simulate};
+use crate::macos::{
+    display_size as _display_size, listen as _listen, simulate as _simulate,
+    stop_listen as _stop_listen,
+};
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -242,7 +245,10 @@ mod windows;
 #[cfg(target_os = "windows")]
 pub use crate::windows::Keyboard;
 #[cfg(target_os = "windows")]
-use crate::windows::{display_size as _display_size, listen as _listen, simulate as _simulate};
+use crate::windows::{
+    display_size as _display_size, listen as _listen, simulate as _simulate,
+    stop_listen as _stop_listen,
+};
 
 /// Listening to global events. Caveat: On MacOS, you require the listen
 /// loop needs to be the primary app (no fork before) and need to have accessibility
@@ -270,6 +276,10 @@ where
     T: FnMut(Event) + 'static,
 {
     _listen(callback)
+}
+
+pub fn stop_listen() {
+    _stop_listen();
 }
 
 /// Sending some events

--- a/src/macos/common.rs
+++ b/src/macos/common.rs
@@ -75,7 +75,7 @@ extern "C" {
     pub fn CFRunLoopGetCurrent() -> CFRunLoopRef;
     pub fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
     pub fn CFRunLoopRun();
-
+    pub fn CFRunLoopStop(rl: CFRunLoopRef);
     pub static kCFRunLoopCommonModes: CFRunLoopMode;
 
 }

--- a/src/macos/common.rs
+++ b/src/macos/common.rs
@@ -101,23 +101,23 @@ pub unsafe fn convert(
     let option_type = match _type {
         CGEventType::LeftMouseDown => Some(EventType::ButtonPress {
             button: Button::Left,
-            x: Some(x),
-            y: Some(y),
+            x,
+            y,
         }),
         CGEventType::LeftMouseUp => Some(EventType::ButtonRelease {
             button: Button::Left,
-            x: Some(x),
-            y: Some(y),
+            x,
+            y,
         }),
         CGEventType::RightMouseDown => Some(EventType::ButtonPress {
             button: Button::Right,
-            x: Some(x),
-            y: Some(y),
+            x,
+            y,
         }),
         CGEventType::RightMouseUp => Some(EventType::ButtonRelease {
             button: Button::Right,
-            x: Some(x),
-            y: Some(y),
+            x,
+            y,
         }),
         CGEventType::MouseMoved => Some(EventType::MouseMove { x, y }),
         CGEventType::KeyDown => {
@@ -147,6 +147,16 @@ pub unsafe fn convert(
                 cg_event.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_2);
             Some(EventType::Wheel { delta_x, delta_y })
         }
+        CGEventType::LeftMouseDragged => Some(EventType::Drag {
+            button: Button::Left,
+            x,
+            y,
+        }),
+        CGEventType::RightMouseDragged => Some(EventType::Drag {
+            button: Button::Right,
+            x,
+            y,
+        }),
         _ => None,
     };
     if let Some(event_type) = option_type {

--- a/src/macos/listen.rs
+++ b/src/macos/listen.rs
@@ -22,7 +22,7 @@ unsafe extern "C" fn raw_callback(
     let opt = KEYBOARD_STATE.lock();
     if let Ok(mut keyboard) = opt {
         if let Some(event) = convert(_type, &cg_event, &mut keyboard) {
-            if let Some(callback) = &mut GLOBAL_CALLBACK {
+            if let Some(ref mut callback) = GLOBAL_CALLBACK {
                 callback(event);
             }
         }

--- a/src/macos/listen.rs
+++ b/src/macos/listen.rs
@@ -59,7 +59,21 @@ where
         CFRunLoopAddSource(current_loop, _loop, kCFRunLoopCommonModes);
 
         CGEventTapEnable(tap, true);
+        STOP_LOOP = Some(Box::new(move || {
+            CFRunLoopStop(current_loop);
+        }));
         CFRunLoopRun();
     }
     Ok(())
 }
+
+pub fn stop_listen() {
+    unsafe {
+        if let Some(stop_loop) = STOP_LOOP.as_ref() {
+            stop_loop();
+        }
+    }
+}
+
+type DynFn = dyn Fn() + 'static;
+pub static mut STOP_LOOP: Option<Box<DynFn>> = None;

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -13,4 +13,5 @@ pub use crate::macos::grab::grab;
 pub use crate::macos::keyboard::Keyboard;
 pub use crate::macos::listen::listen;
 pub use crate::macos::listen::stop_listen;
+pub use crate::macos::simulate::get_current_mouse_location;
 pub use crate::macos::simulate::simulate;

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -12,4 +12,5 @@ pub use crate::macos::display::display_size;
 pub use crate::macos::grab::grab;
 pub use crate::macos::keyboard::Keyboard;
 pub use crate::macos::listen::listen;
+pub use crate::macos::listen::stop_listen;
 pub use crate::macos::simulate::simulate;

--- a/src/macos/simulate.rs
+++ b/src/macos/simulate.rs
@@ -68,16 +68,12 @@ unsafe fn convert_native_with_source(
             )
             .ok()
         }
-        EventType::Drag {
-            button: _,
-            x: _,
-            y: _,
-        } => {
+        EventType::Drag { button: _, x, y } => {
             //https://developer.apple.com/documentation/coregraphics/quartz_event_services?language=objc
             //no drag event in quartz_event_services of coregraphics
-            //you need to use button press, mouse move and release event to simulate drag event
-            //there also has no drag event on windows, so it's fine to replace drag events into press, mouse move and release events.
-            None
+            //simulate drag event into mousemove event
+            let event_type = EventType::MouseMove { x: *x, y: *y };
+            convert_native_with_source(&event_type, source)
         }
     }
 }

--- a/src/macos/simulate.rs
+++ b/src/macos/simulate.rs
@@ -68,12 +68,26 @@ unsafe fn convert_native_with_source(
             )
             .ok()
         }
-        EventType::Drag { button: _, x, y } => {
-            //https://developer.apple.com/documentation/coregraphics/quartz_event_services?language=objc
-            //no drag event in quartz_event_services of coregraphics
-            //simulate drag event into mousemove event
-            let event_type = EventType::MouseMove { x: *x, y: *y };
-            convert_native_with_source(&event_type, source)
+        EventType::Drag { button, x, y } => {
+            let point = CGPoint { x: *x, y: *y };
+            match button {
+                Button::Left => {
+                    let mouse_type = CGEventType::LeftMouseDragged;
+                    CGEvent::new_mouse_event(source, mouse_type, point, CGMouseButton::Left).ok()
+                }
+                Button::Right => {
+                    let mouse_type = CGEventType::RightMouseDragged;
+                    CGEvent::new_mouse_event(source, mouse_type, point, CGMouseButton::Right).ok()
+                }
+                Button::Middle => {
+                    let mouse_type = CGEventType::OtherMouseDragged;
+                    CGEvent::new_mouse_event(source, mouse_type, point, CGMouseButton::Center).ok()
+                }
+                Button::Unknown(_) => {
+                    let mouse_type = CGEventType::OtherMouseDragged;
+                    CGEvent::new_mouse_event(source, mouse_type, point, CGMouseButton::Center).ok()
+                }
+            }
         }
     }
 }

--- a/src/macos/simulate.rs
+++ b/src/macos/simulate.rs
@@ -100,7 +100,7 @@ unsafe fn convert_native(event_type: &EventType) -> Option<CGEvent> {
 ///cause all of button events contain coordinate which can be used when they be simulated.
 ///so you don't need this fn when button press/release anymore.
 #[allow(dead_code)]
-unsafe fn get_current_mouse_location() -> Option<CGPoint> {
+pub unsafe fn get_current_mouse_location() -> Option<CGPoint> {
     let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState).ok()?;
     let event = CGEvent::new(source).ok()?;
     Some(event.location())

--- a/src/macos/simulate.rs
+++ b/src/macos/simulate.rs
@@ -21,8 +21,13 @@ unsafe fn convert_native_with_source(
             let code = code_from_key(*key)?;
             CGEvent::new_keyboard_event(source, code, false).ok()
         }
-        EventType::ButtonPress(button) => {
-            let point = get_current_mouse_location()?;
+        EventType::ButtonPress { button, x, y } => {
+            let mut point = get_current_mouse_location()?;
+            if let Some(x) = x {
+                if let Some(y) = y {
+                    point = CGPoint { x: *x, y: *y };
+                }
+            }
             let event = match button {
                 Button::Left => CGEventType::LeftMouseDown,
                 Button::Right => CGEventType::RightMouseDown,
@@ -36,8 +41,13 @@ unsafe fn convert_native_with_source(
             )
             .ok()
         }
-        EventType::ButtonRelease(button) => {
-            let point = get_current_mouse_location()?;
+        EventType::ButtonRelease { button, x, y } => {
+            let mut point = get_current_mouse_location()?;
+            if let Some(x) = x {
+                if let Some(y) = y {
+                    point = CGPoint { x: *x, y: *y };
+                }
+            }
             let event = match button {
                 Button::Left => CGEventType::LeftMouseUp,
                 Button::Right => CGEventType::RightMouseUp,

--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -233,8 +233,16 @@ pub enum EventType {
     KeyPress(Key),
     KeyRelease(Key),
     /// Mouse Button
-    ButtonPress(Button),
-    ButtonRelease(Button),
+    ButtonPress {
+        button: Button,
+        x: Option<f64>,
+        y: Option<f64>,
+    },
+    ButtonRelease {
+        button: Button,
+        x: Option<f64>,
+        y: Option<f64>,
+    },
     /// Values in pixels. `EventType::MouseMove{x: 0, y: 0}` corresponds to the
     /// top left corner, with x increasing downward and y increasing rightward
     MouseMove {

--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -235,13 +235,18 @@ pub enum EventType {
     /// Mouse Button
     ButtonPress {
         button: Button,
-        x: Option<f64>,
-        y: Option<f64>,
+        x: f64,
+        y: f64,
     },
     ButtonRelease {
         button: Button,
-        x: Option<f64>,
-        y: Option<f64>,
+        x: f64,
+        y: f64,
+    },
+    Drag {
+        button: Button,
+        x: f64,
+        y: f64,
     },
     /// Values in pixels. `EventType::MouseMove{x: 0, y: 0}` corresponds to the
     /// top left corner, with x increasing downward and y increasing rightward

--- a/src/windows/common.rs
+++ b/src/windows/common.rs
@@ -50,6 +50,8 @@ pub unsafe fn get_button_code(lpdata: LPARAM) -> WORD {
 
 pub unsafe fn convert(param: WPARAM, lpdata: LPARAM) -> Option<EventType> {
     let (x, y) = get_point(lpdata);
+    let x = x as f64;
+    let y = y as f64;
     match param.try_into() {
         Ok(WM_KEYDOWN) | Ok(WM_SYSKEYDOWN) => {
             let code = get_code(lpdata);
@@ -63,48 +65,48 @@ pub unsafe fn convert(param: WPARAM, lpdata: LPARAM) -> Option<EventType> {
         }
         Ok(WM_LBUTTONDOWN) => Some(EventType::ButtonPress {
             button: Button::Left,
-            x: Some(x as f64),
-            y: Some(y as f64),
+            x,
+            y,
         }),
         Ok(WM_LBUTTONUP) => Some(EventType::ButtonRelease {
             button: Button::Left,
-            x: Some(x as f64),
-            y: Some(y as f64),
+            x,
+            y,
         }),
         Ok(WM_MBUTTONDOWN) => Some(EventType::ButtonPress {
             button: Button::Middle,
-            x: Some(x as f64),
-            y: Some(y as f64),
+            x,
+            y,
         }),
         Ok(WM_MBUTTONUP) => Some(EventType::ButtonRelease {
             button: Button::Middle,
-            x: Some(x as f64),
-            y: Some(y as f64),
+            x,
+            y,
         }),
         Ok(WM_RBUTTONDOWN) => Some(EventType::ButtonPress {
             button: Button::Right,
-            x: Some(x as f64),
-            y: Some(y as f64),
+            x,
+            y,
         }),
         Ok(WM_RBUTTONUP) => Some(EventType::ButtonRelease {
             button: Button::Right,
-            x: Some(x as f64),
-            y: Some(y as f64),
+            x,
+            y,
         }),
         Ok(WM_XBUTTONDOWN) => {
             let code = get_button_code(lpdata) as u8;
             Some(EventType::ButtonPress {
                 button: Button::Unknown(code),
-                x: Some(x as f64),
-                y: Some(y as f64),
+                x,
+                y,
             })
         }
         Ok(WM_XBUTTONUP) => {
             let code = get_button_code(lpdata) as u8;
             Some(EventType::ButtonRelease {
                 button: Button::Unknown(code),
-                x: Some(x as f64),
-                y: Some(y as f64),
+                x,
+                y,
             })
         }
         Ok(WM_MOUSEMOVE) => Some(EventType::MouseMove {

--- a/src/windows/listen.rs
+++ b/src/windows/listen.rs
@@ -34,7 +34,7 @@ unsafe extern "system" fn raw_callback(code: c_int, param: WPARAM, lpdata: LPARA
                 time: SystemTime::now(),
                 name,
             };
-            if let Some(callback) = &mut GLOBAL_CALLBACK {
+            if let Some(ref mut callback) = GLOBAL_CALLBACK {
                 callback(event);
             }
         }
@@ -58,7 +58,6 @@ where
         loop {
             if let Ok(stop_listen) = receiver.try_recv() {
                 if stop_listen {
-                    println!("stop loop successed");
                     break;
                 }
             }

--- a/src/windows/listen.rs
+++ b/src/windows/listen.rs
@@ -2,6 +2,7 @@ use crate::rdev::{Event, EventType, ListenError};
 use crate::windows::common::{convert, set_key_hook, set_mouse_hook, HookError, HOOK, KEYBOARD};
 use std::os::raw::c_int;
 use std::ptr::null_mut;
+use std::sync::mpsc;
 use std::time::SystemTime;
 use winapi::shared::minwindef::{LPARAM, LRESULT, WPARAM};
 use winapi::um::winuser::{CallNextHookEx, PeekMessageA, HC_ACTION};

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -14,4 +14,5 @@ pub use crate::windows::display::display_size;
 pub use crate::windows::grab::grab;
 pub use crate::windows::keyboard::Keyboard;
 pub use crate::windows::listen::listen;
+pub use crate::windows::listen::stop_listen;
 pub use crate::windows::simulate::simulate;

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -15,4 +15,5 @@ pub use crate::windows::grab::grab;
 pub use crate::windows::keyboard::Keyboard;
 pub use crate::windows::listen::listen;
 pub use crate::windows::listen::stop_listen;
+pub use crate::windows::simulate::get_current_mouse_location;
 pub use crate::windows::simulate::simulate;

--- a/src/windows/simulate.rs
+++ b/src/windows/simulate.rs
@@ -84,14 +84,8 @@ pub fn simulate(event_type: &EventType) -> Result<(), SimulateError> {
             sim_keyboard_event(KEYEVENTF_KEYUP, code, 0)
         }
         EventType::ButtonPress { button, x, y } => {
-            let mut dx = 0;
-            let mut dy = 0;
-            if let Some(x) = x {
-                if let Some(y) = y {
-                    dx = *x as i32;
-                    dy = *y as i32;
-                }
-            }
+            let dx = *x as i32;
+            let dy = *y as i32;
             match button {
                 Button::Left => sim_mouse_event(MOUSEEVENTF_LEFTDOWN, 0, dx, dy),
                 Button::Middle => sim_mouse_event(MOUSEEVENTF_MIDDLEDOWN, 0, dx, dy),
@@ -100,14 +94,8 @@ pub fn simulate(event_type: &EventType) -> Result<(), SimulateError> {
             }
         }
         EventType::ButtonRelease { button, x, y } => {
-            let mut dx = 0;
-            let mut dy = 0;
-            if let Some(x) = x {
-                if let Some(y) = y {
-                    dx = *x as i32;
-                    dy = *y as i32;
-                }
-            }
+            let dx = *x as i32;
+            let dy = *y as i32;
             match button {
                 Button::Left => sim_mouse_event(MOUSEEVENTF_LEFTUP, 0, dx, dy),
                 Button::Middle => sim_mouse_event(MOUSEEVENTF_MIDDLEUP, 0, dx, dy),
@@ -148,6 +136,11 @@ pub fn simulate(event_type: &EventType) -> Result<(), SimulateError> {
                 (*x as i32 + 1) * 65535 / width,
                 (*y as i32 + 1) * 65535 / height,
             )
+        }
+        EventType::Drag { button: _, x, y } => {
+            //if someone copy events from macos to windows, in order to ensure the operation, run drag event as mousemove
+            let event_type = EventType::MouseMove { x: *x, y: *y };
+            simulate(&event_type)
         }
     }
 }

--- a/src/windows/simulate.rs
+++ b/src/windows/simulate.rs
@@ -5,6 +5,8 @@ use std::mem::size_of;
 use winapi::ctypes::{c_int, c_short};
 use winapi::shared::minwindef::{DWORD, UINT, WORD};
 use winapi::shared::ntdef::LONG;
+use winapi::shared::windef::POINT;
+use winapi::um::winuser::GetCursorPos;
 use winapi::um::winuser::{
     GetSystemMetrics, INPUT_u, SendInput, INPUT, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT,
     KEYEVENTF_KEYUP, MOUSEEVENTF_ABSOLUTE, MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN,
@@ -13,6 +15,7 @@ use winapi::um::winuser::{
     MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, MOUSEINPUT, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN,
     WHEEL_DELTA,
 };
+
 /// Not defined in win32 but define here for clarity
 static KEYEVENTF_KEYDOWN: DWORD = 0;
 
@@ -141,6 +144,26 @@ pub fn simulate(event_type: &EventType) -> Result<(), SimulateError> {
             //if someone copy events from macos to windows, in order to ensure the operation, run drag event as mousemove
             let event_type = EventType::MouseMove { x: *x, y: *y };
             simulate(&event_type)
+        }
+    }
+}
+
+type CGFloat = f64;
+pub struct CGPoint {
+    pub x: CGFloat,
+    pub y: CGFloat,
+}
+
+pub unsafe fn get_current_mouse_location() -> Option<CGPoint> {
+    let mut point = POINT { x: 0, y: 0 };
+    unsafe {
+        if GetCursorPos(&mut point as *mut POINT) == 0 {
+            return None;
+        } else {
+            return Some(CGPoint {
+                x: point.x as f64,
+                y: point.y as f64,
+            });
         }
     }
 }

--- a/src/windows/simulate.rs
+++ b/src/windows/simulate.rs
@@ -83,18 +83,38 @@ pub fn simulate(event_type: &EventType) -> Result<(), SimulateError> {
             let code = code_from_key(*key).ok_or(SimulateError)?;
             sim_keyboard_event(KEYEVENTF_KEYUP, code, 0)
         }
-        EventType::ButtonPress(button) => match button {
-            Button::Left => sim_mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0),
-            Button::Middle => sim_mouse_event(MOUSEEVENTF_MIDDLEDOWN, 0, 0, 0),
-            Button::Right => sim_mouse_event(MOUSEEVENTF_RIGHTDOWN, 0, 0, 0),
-            Button::Unknown(code) => sim_mouse_event(MOUSEEVENTF_XDOWN, (*code).into(), 0, 0),
-        },
-        EventType::ButtonRelease(button) => match button {
-            Button::Left => sim_mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0),
-            Button::Middle => sim_mouse_event(MOUSEEVENTF_MIDDLEUP, 0, 0, 0),
-            Button::Right => sim_mouse_event(MOUSEEVENTF_RIGHTUP, 0, 0, 0),
-            Button::Unknown(code) => sim_mouse_event(MOUSEEVENTF_XUP, (*code).into(), 0, 0),
-        },
+        EventType::ButtonPress { button, x, y } => {
+            let mut dx = 0;
+            let mut dy = 0;
+            if let Some(x) = x {
+                if let Some(y) = y {
+                    dx = *x as i32;
+                    dy = *y as i32;
+                }
+            }
+            match button {
+                Button::Left => sim_mouse_event(MOUSEEVENTF_LEFTDOWN, 0, dx, dy),
+                Button::Middle => sim_mouse_event(MOUSEEVENTF_MIDDLEDOWN, 0, dx, dy),
+                Button::Right => sim_mouse_event(MOUSEEVENTF_RIGHTDOWN, 0, dx, dy),
+                Button::Unknown(code) => sim_mouse_event(MOUSEEVENTF_XDOWN, (*code).into(), dx, dy),
+            }
+        }
+        EventType::ButtonRelease { button, x, y } => {
+            let mut dx = 0;
+            let mut dy = 0;
+            if let Some(x) = x {
+                if let Some(y) = y {
+                    dx = *x as i32;
+                    dy = *y as i32;
+                }
+            }
+            match button {
+                Button::Left => sim_mouse_event(MOUSEEVENTF_LEFTUP, 0, dx, dy),
+                Button::Middle => sim_mouse_event(MOUSEEVENTF_MIDDLEUP, 0, dx, dy),
+                Button::Right => sim_mouse_event(MOUSEEVENTF_RIGHTUP, 0, dx, dy),
+                Button::Unknown(code) => sim_mouse_event(MOUSEEVENTF_XUP, (*code).into(), dx, dy),
+            }
+        }
         EventType::Wheel { delta_x, delta_y } => {
             if *delta_x != 0 {
                 sim_mouse_event(

--- a/tests/listen_and_simulate.rs
+++ b/tests/listen_and_simulate.rs
@@ -53,8 +53,16 @@ fn test_listen_and_simulate() -> Result<(), Box<dyn Error>> {
         //EventType::KeyPress(Key::ShiftLeft),
         EventType::KeyPress(Key::KeyS),
         EventType::KeyRelease(Key::KeyS),
-        EventType::ButtonPress(Button::Right),
-        EventType::ButtonRelease(Button::Right),
+        EventType::ButtonPress {
+            button: Button::Right,
+            x: None,
+            y: None,
+        },
+        EventType::ButtonRelease {
+            button: Button::Right,
+            x: None,
+            y: None,
+        },
         EventType::Wheel {
             delta_x: 0,
             delta_y: 1,
@@ -70,5 +78,6 @@ fn test_listen_and_simulate() -> Result<(), Box<dyn Error>> {
         y: pixel as f64,
     });
     let mut events = events.chain(click_events);
+    //how to fix it? todo
     sim_then_listen(&mut events)
 }

--- a/tests/stop_listen.rs
+++ b/tests/stop_listen.rs
@@ -1,0 +1,23 @@
+use rdev::{listen, stop_listen};
+use serial_test::serial;
+use std::{
+    thread::{self, spawn},
+    time::Duration,
+};
+#[test]
+#[serial]
+fn test_stop() {
+    eprintln!("hello");
+    spawn(|| {
+        if let Err(error) = listen(|event| {
+            println!("My callback {:?}", event);
+        }) {
+            println!("Error: {:?}", error)
+        }
+    });
+    thread::sleep(Duration::from_secs(5));
+    spawn(|| {
+        stop_listen();
+    });
+    thread::sleep(Duration::from_secs(5));
+}


### PR DESCRIPTION
Supported on macos and windows, this branch is based on my stop_listen branch.

drag event type like this:
`Drag { button: Left, x: 2447.921875, y: 805.1796875 }`

It also can be simulated smoothly.

I also provide the coordinate in press and release event, their types like this:
`ButtonPress { button: Left, x: 2570.92578125, y: 797.49609375 }`
`ButtonRelease { button: Left, x: 2570.92578125, y: 797.49609375 }`