### PR TITLE
Add support for listening to media keys and other special keys on macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ serialize = ["serde"]
 unstable_grab = ["evdev-rs", "epoll", "inotify"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.22"
-core-graphics = {version = "0.19.0", features = ["highsierra"]}
-core-foundation = {version = "0.7"}
-core-foundation-sys = {version = "0.7"}
+cocoa = "0.26.0"
+core-graphics = {version = "0.24.0", features = ["highsierra"] }
+core-foundation = {version = "0.10.0" }
+core-foundation-sys = {version = "0.8.7" }
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/macos/keycodes.rs
+++ b/src/macos/keycodes.rs
@@ -251,6 +251,65 @@ pub fn key_from_code(code: CGKeyCode) -> Key {
     }
 }
 
+//https://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-308/IOHIDSystem/IOKit/hidsystem/ev_keymap.h
+
+/*
+ * Special keys currently known to and understood by the system.
+ * If new specialty keys are invented, extend this list as appropriate.
+ * The presence of these keys in a particular implementation is not
+ * guaranteed.
+ */
+const NX_NOSPECIALKEY: u32 = 0xFFFF;
+const NX_KEYTYPE_SOUND_UP: u32 = 0;
+const NX_KEYTYPE_SOUND_DOWN: u32 = 1;
+const NX_KEYTYPE_BRIGHTNESS_UP: u32 = 2;
+const NX_KEYTYPE_BRIGHTNESS_DOWN: u32 = 3;
+const NX_KEYTYPE_CAPS_LOCK: u32 = 4;
+const NX_KEYTYPE_HELP: u32 = 5;
+const NX_POWER_KEY: u32 = 6;
+const NX_KEYTYPE_MUTE: u32 = 7;
+const NX_UP_ARROW_KEY: u32 = 8;
+const NX_DOWN_ARROW_KEY: u32 = 9;
+const NX_KEYTYPE_NUM_LOCK: u32 = 10;
+
+const NX_KEYTYPE_CONTRAST_UP: u32 = 11;
+const NX_KEYTYPE_CONTRAST_DOWN: u32 = 12;
+const NX_KEYTYPE_LAUNCH_PANEL: u32 = 13;
+const NX_KEYTYPE_EJECT: u32 = 14;
+const NX_KEYTYPE_VIDMIRROR: u32 = 15;
+
+const NX_KEYTYPE_PLAY: u32 = 16;
+const NX_KEYTYPE_NEXT: u32 = 17;
+const NX_KEYTYPE_PREVIOUS: u32 = 18;
+const NX_KEYTYPE_FAST: u32 = 19;
+const NX_KEYTYPE_REWIND: u32 = 20;
+
+const NX_KEYTYPE_ILLUMINATION_UP: u32 = 21;
+const NX_KEYTYPE_ILLUMINATION_DOWN: u32 = 22;
+const NX_KEYTYPE_ILLUMINATION_TOGGLE: u32 = 23;
+
+const NX_NUMSPECIALKEYS: u32 = 24; /* Maximum number of special keys */
+const NX_NUM_SCANNED_SPECIALKEYS: u32 = 24; /* First 24 special keys are */
+/* actively scanned in kernel */
+
+pub fn key_from_special_key(code: u32) -> Key {
+    match code {
+        NX_KEYTYPE_SOUND_UP => Key::VolumeUp,
+        NX_KEYTYPE_SOUND_DOWN => Key::VolumeDown,
+        NX_KEYTYPE_MUTE => Key::VolumeMute,
+        NX_KEYTYPE_BRIGHTNESS_UP => Key::BrightnessUp,
+        NX_KEYTYPE_BRIGHTNESS_DOWN => Key::BrightnessDown,
+        NX_KEYTYPE_PLAY => Key::PlayPause,
+        NX_KEYTYPE_NEXT => Key::NextTrack,
+        NX_KEYTYPE_PREVIOUS => Key::PreviousTrack,
+        NX_KEYTYPE_CAPS_LOCK => Key::CapsLock,
+        NX_UP_ARROW_KEY => Key::UpArrow,
+        NX_DOWN_ARROW_KEY => Key::DownArrow,
+        NX_KEYTYPE_NUM_LOCK => Key::NumLock,
+        code => Key::UnknownSpecialKey(code.into()),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{code_from_key, key_from_code};

--- a/src/macos/keycodes.rs
+++ b/src/macos/keycodes.rs
@@ -292,21 +292,21 @@ const NX_NUMSPECIALKEYS: u32 = 24; /* Maximum number of special keys */
 const NX_NUM_SCANNED_SPECIALKEYS: u32 = 24; /* First 24 special keys are */
 /* actively scanned in kernel */
 
-pub fn key_from_special_key(code: u32) -> Key {
+pub fn key_from_special_key(code: u32) -> Option<Key> {
     match code {
-        NX_KEYTYPE_SOUND_UP => Key::VolumeUp,
-        NX_KEYTYPE_SOUND_DOWN => Key::VolumeDown,
-        NX_KEYTYPE_MUTE => Key::VolumeMute,
-        NX_KEYTYPE_BRIGHTNESS_UP => Key::BrightnessUp,
-        NX_KEYTYPE_BRIGHTNESS_DOWN => Key::BrightnessDown,
-        NX_KEYTYPE_PLAY => Key::PlayPause,
-        NX_KEYTYPE_NEXT => Key::NextTrack,
-        NX_KEYTYPE_PREVIOUS => Key::PreviousTrack,
-        NX_KEYTYPE_CAPS_LOCK => Key::CapsLock,
-        NX_UP_ARROW_KEY => Key::UpArrow,
-        NX_DOWN_ARROW_KEY => Key::DownArrow,
-        NX_KEYTYPE_NUM_LOCK => Key::NumLock,
-        code => Key::UnknownSpecialKey(code.into()),
+        NX_KEYTYPE_SOUND_UP => Some(Key::VolumeUp),
+        NX_KEYTYPE_SOUND_DOWN => Some(Key::VolumeDown),
+        NX_KEYTYPE_MUTE => Some(Key::VolumeMute),
+        NX_KEYTYPE_BRIGHTNESS_UP => Some(Key::BrightnessUp),
+        NX_KEYTYPE_BRIGHTNESS_DOWN => Some(Key::BrightnessDown),
+        NX_KEYTYPE_PLAY => Some(Key::PlayPause),
+        NX_KEYTYPE_NEXT => Some(Key::NextTrack),
+        NX_KEYTYPE_PREVIOUS => Some(Key::PreviousTrack),
+        NX_KEYTYPE_CAPS_LOCK => Some(Key::CapsLock),
+        NX_UP_ARROW_KEY => Some(Key::UpArrow),
+        NX_DOWN_ARROW_KEY => Some(Key::DownArrow),
+        NX_KEYTYPE_NUM_LOCK => Some(Key::NumLock),
+        _ => None,
     }
 }
 

--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -217,7 +217,6 @@ pub enum Key {
     PlayPause,
     NextTrack,
     Unknown(u32),
-    UnknownSpecialKey(u32),
 }
 
 /// Standard mouse buttons

--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -208,7 +208,16 @@ pub enum Key {
     Kp9,
     KpDelete,
     Function,
+    VolumeUp,
+    VolumeDown,
+    VolumeMute,
+    BrightnessUp,
+    BrightnessDown,
+    PreviousTrack,
+    PlayPause,
+    NextTrack,
     Unknown(u32),
+    UnknownSpecialKey(u32),
 }
 
 /// Standard mouse buttons

--- a/src/windows/keycodes.rs
+++ b/src/windows/keycodes.rs
@@ -132,7 +132,13 @@ decl_keycodes! {
     Kp7, 103,
     Kp8, 104,
     Kp9, 105,
-    KpDelete, 110
+    KpDelete, 110,
+    VolumeMute: 173,
+    VolumeDown: 174,
+    VolumeUp: 175,
+    NextTrack: 176,
+    PreviousTrack: 177,
+    PlayPause: 179,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Media keys like play/pause/mute/volume up/down did not work until these changes. They are considered "special keys" in macos and required some extra work to make the callbacks work.

References:
https://github.com/nhurden/MediaKeyTap/blob/master/MediaKeyTap/NSEventExtensions.swift
https://github.com/nhurden/MediaKeyTap/blob/master/MediaKeyTap/MediaKeyTapInternals.swift