### PR TITLE
feat: enable mouse move event on mouse drag for macos

### DIFF
--- a/src/macos/common.rs
+++ b/src/macos/common.rs
@@ -108,6 +108,20 @@ pub unsafe fn convert(
                 y: point.y,
             })
         }
+        CGEventType::LeftMouseDragged => {
+            let point = cg_event.location();
+            Some(EventType::MouseMove {
+                x: point.x,
+                y: point.y,
+            })
+        }
+        CGEventType::RightMouseDragged => {
+            let point = cg_event.location();
+            Some(EventType::MouseMove {
+                x: point.x,
+                y: point.y,
+            })
+        }
         CGEventType::KeyDown => {
             let code = cg_event.get_integer_value_field(EventField::KEYBOARD_EVENT_KEYCODE);
             Some(EventType::KeyPress(key_from_code(code.try_into().ok()?)))


### PR DESCRIPTION
On MacOS, when mouse is pressed, no move event is emitted. 
This prevents me from detecting drag event.

On both windows and linux, move event is emitted when mouse is pressed.

I think it's a better idea to add `MouseDrag` event to `EventType`, because Mac's native API already have this `CGEventType::LeftMouseDragged`.

But this requires also updating windows and linux API to stay consistent. 
I may work on that later. This PR makes `rdev` behave the same way on all platforms.