### PR TITLE
Supporting media keys on macos.

### DIFF
--- a/src/macos/keycodes.rs
+++ b/src/macos/keycodes.rs
@@ -252,6 +252,82 @@ pub fn key_from_code(code: CGKeyCode) -> Key {
     }
 }
 
+//https://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-308/IOHIDSystem/IOKit/hidsystem/ev_keymap.h
+// https://github.com/acidanthera/MacKernelSDK/blob/master/Headers/IOKit/hidsystem/ev_keymap.h
+
+/*
+ * Special keys currently known to and understood by the system.
+ * If new specialty keys are invented, extend this list as appropriate.
+ * The presence of these keys in a particular implementation is not
+ * guaranteed.
+ */
+
+#[allow(unused)]
+const NX_NOSPECIALKEY: u32 = 0xFFFF;
+const NX_KEYTYPE_SOUND_UP: u32 = 0;
+const NX_KEYTYPE_SOUND_DOWN: u32 = 1;
+const NX_KEYTYPE_BRIGHTNESS_UP: u32 = 2;
+const NX_KEYTYPE_BRIGHTNESS_DOWN: u32 = 3;
+const NX_KEYTYPE_CAPS_LOCK: u32 = 4;
+#[allow(unused)]
+const NX_KEYTYPE_HELP: u32 = 5;
+#[allow(unused)]
+const NX_POWER_KEY: u32 = 6;
+const NX_KEYTYPE_MUTE: u32 = 7;
+const NX_UP_ARROW_KEY: u32 = 8;
+const NX_DOWN_ARROW_KEY: u32 = 9;
+const NX_KEYTYPE_NUM_LOCK: u32 = 10;
+
+#[allow(unused)]
+const NX_KEYTYPE_CONTRAST_UP: u32 = 11;
+#[allow(unused)]
+const NX_KEYTYPE_CONTRAST_DOWN: u32 = 12;
+#[allow(unused)]
+const NX_KEYTYPE_LAUNCH_PANEL: u32 = 13;
+#[allow(unused)]
+const NX_KEYTYPE_EJECT: u32 = 14;
+#[allow(unused)]
+const NX_KEYTYPE_VIDMIRROR: u32 = 15;
+
+const NX_KEYTYPE_PLAY: u32 = 16;
+const NX_KEYTYPE_NEXT: u32 = 17;
+const NX_KEYTYPE_PREVIOUS: u32 = 18;
+#[allow(unused)]
+const NX_KEYTYPE_FAST: u32 = 19;
+#[allow(unused)]
+const NX_KEYTYPE_REWIND: u32 = 20;
+
+#[allow(unused)]
+const NX_KEYTYPE_ILLUMINATION_UP: u32 = 21;
+#[allow(unused)]
+const NX_KEYTYPE_ILLUMINATION_DOWN: u32 = 22;
+#[allow(unused)]
+const NX_KEYTYPE_ILLUMINATION_TOGGLE: u32 = 23;
+
+#[allow(unused)]
+const NX_NUMSPECIALKEYS: u32 = 24; /* Maximum number of special keys */
+#[allow(unused)]
+const NX_NUM_SCANNED_SPECIALKEYS: u32 = 24; /* First 24 special keys are */
+/* actively scanned in kernel */
+
+pub fn key_from_special_key(code: u32) -> Option<Key> {
+    match code {
+        NX_KEYTYPE_SOUND_UP => Some(Key::VolumeUp),
+        NX_KEYTYPE_SOUND_DOWN => Some(Key::VolumeDown),
+        NX_KEYTYPE_MUTE => Some(Key::VolumeMute),
+        NX_KEYTYPE_BRIGHTNESS_UP => Some(Key::BrightnessUp),
+        NX_KEYTYPE_BRIGHTNESS_DOWN => Some(Key::BrightnessDown),
+        NX_KEYTYPE_PLAY => Some(Key::PlayPause),
+        NX_KEYTYPE_NEXT => Some(Key::NextTrack),
+        NX_KEYTYPE_PREVIOUS => Some(Key::PreviousTrack),
+        NX_KEYTYPE_CAPS_LOCK => Some(Key::CapsLock),
+        NX_UP_ARROW_KEY => Some(Key::UpArrow),
+        NX_DOWN_ARROW_KEY => Some(Key::DownArrow),
+        NX_KEYTYPE_NUM_LOCK => Some(Key::NumLock),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{code_from_key, key_from_code};


### PR DESCRIPTION
Superseeds: https://github.com/Narsil/rdev/pull/144 after migration to obj2 (Somehow this branch works for me where original PR didn't)