### PR TITLE
Add dwExtraInfo to Event struct in Windows implementation

### DIFF
--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -283,6 +283,8 @@ pub struct Event {
     pub time: SystemTime,
     pub name: Option<String>,
     pub event_type: EventType,
+    #[cfg(target_os = "windows")]
+    pub extra_info: u32,
 }
 
 /// We can define a dummy Keyboard, that we will use to detect

--- a/src/windows/grab.rs
+++ b/src/windows/grab.rs
@@ -10,7 +10,7 @@ unsafe extern "system" fn raw_callback(code: i32, param: usize, lpdata: isize) -
     unsafe {
         if code == HC_ACTION {
             let opt = convert(param, lpdata);
-            if let Some(event_type) = opt {
+            if let Some((event_type, extra_info)) = opt {
                 let name = match &event_type {
                     EventType::KeyPress(_key) => match (*KEYBOARD).lock() {
                         Ok(mut keyboard) => keyboard.get_name(lpdata),
@@ -22,6 +22,7 @@ unsafe extern "system" fn raw_callback(code: i32, param: usize, lpdata: isize) -
                     event_type,
                     time: SystemTime::now(),
                     name,
+                    extra_info,
                 };
                 let ptr = &raw mut GLOBAL_CALLBACK;
                 if let Some(callback) = &mut *ptr {

--- a/src/windows/listen.rs
+++ b/src/windows/listen.rs
@@ -21,7 +21,7 @@ unsafe extern "system" fn raw_callback(code: c_int, param: WPARAM, lpdata: LPARA
     unsafe {
         if code == HC_ACTION {
             let opt = convert(param, lpdata);
-            if let Some(event_type) = opt {
+            if let Some((event_type, extra_info)) = opt {
                 let name = match &event_type {
                     EventType::KeyPress(_key) => match (*KEYBOARD).lock() {
                         Ok(mut keyboard) => keyboard.get_name(lpdata),
@@ -33,6 +33,7 @@ unsafe extern "system" fn raw_callback(code: c_int, param: WPARAM, lpdata: LPARA
                     event_type,
                     time: SystemTime::now(),
                     name,
+                    extra_info,
                 };
                 let ptr = &raw mut GLOBAL_CALLBACK;
                 if let Some(callback) = &mut *ptr {


### PR DESCRIPTION
This allows users to access the Windows-specific `dwExtraInfo` field that comes in with each event when using the crate compiled for Windows. 

This changes the public API of the `Event` struct by adding a conditionally field `pub extra_info: u32` on Windows targets.

### Cross-platform considerations

- On macOS, there is a partial analogue (`kCGEventSourceUserData`). Could be integrated if more cross-platform support is needed.

- On X11/Wayland, I did not find a clear parallel after surveying XInput2 and Wayland protocols. Input welcome if there’s a known equivalent.

I considered adding some kind of all-platform `user_data` field (`Option<u32>`) that is `None` on non-Windows, but decided against it to avoid implying consistent support across all platforms where it doesn’t exist.