### PR TITLE
fix(wayland): prevent libinput unset axis error on scroll

### DIFF
--- a/src/linux/wayland/listen.rs
+++ b/src/linux/wayland/listen.rs
@@ -5,7 +5,7 @@ use crate::rdev::{Event, KeyboardState, ListenError};
 use crate::{Button, EventType};
 use input::event::PointerEvent;
 use input::event::keyboard::{KeyState, KeyboardEventTrait};
-use input::event::pointer::{Axis, ButtonState};
+use input::event::pointer::{Axis, ButtonState, PointerScrollEvent};
 use input::{Event as LibEvent, Libinput, LibinputInterface};
 use libc::{O_RDONLY, O_RDWR, O_WRONLY};
 use std::fs::{File, OpenOptions};

--- a/src/linux/wayland/listen.rs
+++ b/src/linux/wayland/listen.rs
@@ -51,10 +51,21 @@ fn convert_type(libevent: LibEvent) -> Option<EventType> {
             x: btn.absolute_x(),
             y: btn.absolute_y(),
         }),
-        LibEvent::Pointer(PointerEvent::ScrollWheel(btn)) => Some(EventType::Wheel {
-            delta_x: -(btn.scroll_value_v120(Axis::Horizontal) / 120.0) as i64,
-            delta_y: -(btn.scroll_value_v120(Axis::Vertical) / 120.0) as i64,
-        }),
+        LibEvent::Pointer(PointerEvent::ScrollWheel(btn)) => {
+            let delta_x = if btn.has_axis(Axis::Horizontal) {
+                -(btn.scroll_value_v120(Axis::Horizontal) / 120.0) as i64
+            } else {
+                0
+            };
+
+            let delta_y = if btn.has_axis(Axis::Vertical) {
+                -(btn.scroll_value_v120(Axis::Vertical) / 120.0) as i64
+            } else {
+                0
+            };
+
+            Some(EventType::Wheel { delta_x, delta_y })
+        }
         _ => {
             // dbg!(format!("Received unhandlded event {lib:?}"));
             None


### PR DESCRIPTION
### Description
This PR fixes an issue where scrolling a mouse wheel under Wayland causes `libinput` to aggressively spam the console with the following error:
`libinput error: client bug: value requested for unset axis`

**The Cause:**
Currently, when a `PointerScrollWheelEvent` is received, the code unconditionally requests both `Axis::Horizontal` and `Axis::Vertical` values. If the physical mouse only triggered a vertical scroll, requesting the horizontal axis triggers a safety check inside `libinput`, resulting in the "client bug" error.

**The Fix:**
I imported the `PointerScrollEvent` trait and wrapped the axis value requests in an `if btn.has_axis(...)` check. If the axis wasn't triggered by the hardware, it safely defaults to `0` instead of querying `libinput`.

### Changes Made
* Added `use input::event::pointer::PointerScrollEvent;` to imports.
* Updated the `PointerEvent::ScrollWheel(btn)` match arm to verify axis existence before calculating `delta_x` and `delta_y`.

### Additional Context
I ran into this while building a macro recorder for Wayland. My engine bypasses user-space jitter by using `evdev` directly for recording, but I am still using `rdev` to listen for global hotkeys (like F-keys) to start/stop the macros. 

Whenever I scrolled my mouse wheel, this Wayland axis bug would trigger and spam my macro engine's terminal output. This fix keeps the console completely clean!